### PR TITLE
Fix job control in console for Panda and Penguin

### DIFF
--- a/console.c
+++ b/console.c
@@ -4,10 +4,23 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <signal.h>
 
 // Bind a shell to a serial console and ensure
 // the session has support for job control (e.g.,
 // ctrl+c, ctrl+z)
+
+// Explicitly re-raise the signal to the default handler
+
+void handle_sigint(int sig) {
+    signal(sig, SIG_DFL);
+    raise(sig);
+}
+
+void handle_sigtstp(int sig) {
+    signal(sig, SIG_DFL);
+    raise(sig);
+}
 
 int main(int argc, char **argv) {
     int fd;
@@ -42,6 +55,10 @@ int main(int argc, char **argv) {
 
     putenv("TERM=linux");
     putenv("PATH=/sbin:/bin:/usr/sbin:/usr/bin");
+
+    // Set up signal handlers for SIGINT and SIGTSTP
+    signal(SIGINT, handle_sigint);
+    signal(SIGTSTP, handle_sigtstp);
 
     return execl(SHELL, SHELL, NULL);
 }


### PR DESCRIPTION
This PR does two things, fixing Job Control in two scenarios.

1. **Scenario**: you run Panda with two serial devices, exposing the second over telnet. **Problem**: Job Control was not working because the curproc was the session (process group) leader, thus not allowing `setsid()` to create a new session ([setsid() man page](https://man7.org/linux/man-pages/man2/setsid.2.html)). **Solution**: `fork()` before calling `setsid()`
2. **Scenario**: you run Penguin and connect to the shell exposed over telnet. **Problem**: Ctrl+C was not working as expected. The character gets rendered in the output, but no SIGINT is raised. **Solution**: explicitly re-raise the proper signal with its default handler (`SIG_DFL`)